### PR TITLE
cosmetic fixes

### DIFF
--- a/jupyterhub_user_manual.md
+++ b/jupyterhub_user_manual.md
@@ -9,13 +9,13 @@ JupyterHubへのアクセスはLDAP認証を用いているため、まずLDAP�
 ## アクセス手順
 認証の都合でJupyterHubのページに直接アクセスする前に一度だけSSH経由でのアクセスが必要になっています。一度アクセスを行うとユーザの設定が完了するので以降は直接URLにアクセスしログインすれば問題ありません。以下のコマンドを用いて、申請の際に伝えられたパスワードを入力しゲートウェイにログインを行って下さい。
 
-```sh
+```
 ssh -p 2221 [ユーザ名]@karen.ai.hc.keio.ac.jp
 ```
 
 ログインが完了するとパスワードを変更するよう促されるので、パスワードを変更した後そこからもう一度SSHを行いJupyterHubのサーバにアクセスします。新しく設定したパスワードを用いてログインを行うことができます。
 
-```sh
+```
 ssh [ユーザ名]@jupyterhub-container.lxd
 ```
 
@@ -44,4 +44,4 @@ ipyton kernel install --user --name custom-env
 
 ![](./images/jupyterhub.png)
 
-参考: [https://zonca.github.io/2017/02/customize-python-environment-jupyterhub.html](https://zonca.github.io/2017/02/customize-python-environment-jupyterhub.html)
+参考: <https://zonca.github.io/2017/02/customize-python-environment-jupyterhub.html>

--- a/user_manual.md
+++ b/user_manual.md
@@ -6,13 +6,13 @@
 ## アクセス手順
 特別な申請が無い限り、利用者に割り当てられるコンテナはNATされたネットワークに繋がっているため、直接SSHすることができません。したがって、一旦サーバ上で動いているゲートウェイコンテナにSSHでログインし、そこからもう一度SSHして自分のコンテナにアクセスする必要があります。ゲートウェイコンテナはサーバの2221番ポートからSSHできるようになっているため、コンテナの割当時に伝えられたサーバにまずSSHします。
 
-```sh
-ssh -p 2221 [ユーザ名]@[サーバIP(*ai.hc.keio.ac.jp)]
+```
+ssh -p 2221 [ユーザ名]@[サーバIP(*.ai.hc.keio.ac.jp)]
 ```
 
 ここでゲートウェイコンテナのパスワードを入力します。次に割り当てられたコンテナにSSHします。
 
-```bash
+```
 ssh ubuntu@[コンテナ名もしくはコンテナIP]
 ```
 
@@ -26,12 +26,12 @@ ssh ubuntu@[コンテナ名もしくはコンテナIP]
 GPUの利用について
 GPUの利用申請があったユーザにはCUDA 10.1・cuDNN 7・Anaconda3をコンテナにインストールした状態で提供しています。次のコードで簡単に動作確認をすることができます。まずは、通常のSSHと同時にポートフォワーディングを行うため、
 
-```sh
-ssh -p 2221 -L 8888:[コンテナIP]:8888 [ユーザ名]@[サーバIP(*ai.hc.keio.ac.jp)
+```
+ssh -p 2221 -L 8888:[コンテナIP]:8888 [ユーザ名]@[サーバIP(*.ai.hc.keio.ac.jp)
 ```
 
 でゲートウェイコンテナにログインを行い、そこからは
-```sh
+```
 ssh ubuntu@[コンテナIP]`
 ```
 でユーザコンテナにログインをします。
@@ -54,4 +54,4 @@ export PATH=$PATH:$HOME/anaconda3/bin
 . /home/ubuntu/anaconda3/etc/profile.d/conda.sh
 ```
 
-参考: [https://docs.anaconda.com/anaconda/install/uninstall/](https://docs.anaconda.com/anaconda/install/uninstall/)
+参考: <https://docs.anaconda.com/anaconda/install/uninstall/>

--- a/user_manual.md
+++ b/user_manual.md
@@ -38,7 +38,7 @@ ssh ubuntu@[コンテナIP]`
 ユーザコンテナにログインできた後、次のコマンドの実行をします。
 
 ```sh
-conda create -n test_env python=3.6 anaconda keras-gpu # 時間が掛かるので注意
+conda create -n test_env anaconda tensorflow-gpu # 時間が掛かるので注意
 conda activate test_env
 wget 'https://raw.githubusercontent.com/tensorflow/docs/master/site/en/tutorials/keras/classification.ipynb' # Tensorflowのチュートリアル用ipynbファイル
 jupyter notebook --ip=0.0.0.0


### PR DESCRIPTION
- sh指定すると変なところがハイライトされてしまうのでそのfix
- Markdownリンク記法の利用
- globを分かりやすく（`*ai` -> `*.ai`）