### PR TITLE
パッケージの追加方法についての説明の削除

### DIFF
--- a/jupyterhub_user_manual.md
+++ b/jupyterhub_user_manual.md
@@ -23,7 +23,7 @@ ssh -p 2221 user@tippy.ai.hc.keio.ac.jp
 
 再び同じ場所にSSHアクセスを行い、これで正常にログインができれば設定は完了です。接続を切り、ブラウザで [https://cocoa.ai.hc.keio.ac.jp](https://cocoa.ai.hc.keio.ac.jp) にアクセスしてください。ここで、`https`ではなく`http`と打ってしまうと正しくアクセスできないので注意して下さい。出てきたログインフォームにてユーザ名と新しく設定したパスワードを入力するとログインができます。
 
-## カスタムパッケージ追加の方法
+<!-- ## カスタムパッケージ追加の方法
 condaやpipのパッケージを入れようとしても、パーミッション関係のエラーが出てきます。そこで、次のようにするとcondaやpipで独自のパッケージを自由にインストールできるようになります。まず、SSHやJupyter Notebookのターミナル等でシェルを得た後、condaの初期設定を次のコマンドで行います。
 
 ```sh
@@ -43,4 +43,4 @@ ipython kernel install --user --name custom-env
 
 ![](./images/jupyterhub.png)
 
-参考: <https://zonca.github.io/2017/02/customize-python-environment-jupyterhub.html>
+参考: <https://zonca.github.io/2017/02/customize-python-environment-jupyterhub.html> -->


### PR DESCRIPTION
# WHAT

JupyterHubでユーザがパッケージを追加する際の権限の問題を回避するためにAnacondaで環境構築をしなくてはならない，という記述を削除

# WHY

ユーザからの報告を受けて検証してみたところ，今までの説明文どおりにやると `ipython kernel install --user --name custom-env` で `No module named ‘IPython’` というエラーが出る．
エラー内容通りにaptでipythonをインストールしても解決できない．
また普通にpip installで任意のパッケージをインストールできるので，現状では権限の問題はクリアできている (はず)．